### PR TITLE
add cups-controls support to see printers

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,7 @@ apps:
       - browser-support
       - home
       - removable-media
+      - cups-control
     environment:
       HOME: $SNAP_USER_COMMON
       XDG_CONFIG_HOME: $SNAP_USER_COMMON


### PR DESCRIPTION
Currently it is not possible to print using the snap zotero. By adding the cups-control plugin, the app can access the printers on the system.