### PR TITLE
Tidy Snapcraft workflow

### DIFF
--- a/.github/workflows/snapcraft.yml
+++ b/.github/workflows/snapcraft.yml
@@ -1,48 +1,23 @@
+# This workflow publishes a snap on updates to the master and beta branch
+
 name: snapcraft
-
-on: push
-
+on:
+  push:
+    branches:
+      - master
+      - beta
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
-    outputs:
-      snap-file: ${{ steps.build.outputs.snap }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: snapcore/action-build@v1
-      id: build
-    - uses: actions/upload-artifact@v3
-      with:
-        name: snap
-        path: ${{ steps.build.outputs.snap }}
-
-  push-master:
-    needs: build
-    runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: snap
-          path: .
-      - uses: snapcore/action-publish@master
+      - uses: actions/checkout@v3
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+      - name: Publish to the Snap Store
+        uses: snapcore/action-publish@master
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_LOGIN }}
         with:
-          snap: ${{needs.build.outputs.snap-file}}
-          release: candidate
-  push-beta:
-    needs: build
-    runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/beta'
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: snap
-          path: .
-      - uses: snapcore/action-publish@master
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_LOGIN }}
-        with:
-          snap: ${{needs.build.outputs.snap-file}}
-          release: beta
+          snap: ${{ steps.build.outputs.snap }}
+          release: ${{ github.ref_name == 'master' && 'candidate' || 'beta' }}


### PR DESCRIPTION
If accepted, this refactoring will simplify the project's `snapcraft`  workflow.

The goal is to make the build system easier to review and maintain, and prepare for new features.

### Changes:
1. Merge `build`, `push_beta`, and `push_master` jobs into the `publish` job
2. Inline release channel logic:
```bash
 release: ${{ github.ref_name == 'master' && 'candidate' || 'beta' }}
 ```
Note: `github.ref_name` is the shortened branch name.

5. Filter branches with on.push rule:
```bash
on:
  push:
    branches:
      - master
      - beta
```
6. Add step names and explanation header 
3. Eliminate the artifact cache


### Testing 

This test run indicates that the snap still builds:  [(19720621675)](https://github.com/maxsu/zotero-snap/actions/runs/7239109987/job/19720621675)

We must still verify publishing.


### Breaking Change: Removing Artifact Cache

In the original workflow, we use artifacts to transfer the built snap between jobs. However, artifacts also allow us to manually download and inspect build artifacts from workflow runs. Removing the cache simplifies the workflow, but breaks the ability to download artifacts.

Is this acceptable?

---

### Conclusion

In summary, this PR aims to streamline our `snapcraft` workflow by consolidating jobs, inlining logic, and refining branch filters, enhancing the build system's reviewability and maintainability. The removal of the artifact cache is a significant change, but I believe the simplification justifies the decision.

**Next Steps**

Upon approval we will:

1. Verify publishing
2. Monitor the system closely for immediate issues
3. Respond rapidly to unforeseen problems

I welcome any feedback or suggestions on these changes. My commitment is to ensure a smooth transition and to promptly address any challenges that may arise.

Thank you for considering these improvements!