### PR TITLE
Un-disable Wayland support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,7 +43,6 @@ apps:
     environment:
       HOME: $SNAP_USER_COMMON
       XDG_CONFIG_HOME: $SNAP_USER_COMMON
-      DISABLE_WAYLAND: 1
     slots:
       - dbus-daemon
 


### PR DESCRIPTION
Wayland support appears to be working, so I removed the environment variable to disable it.

It appears Wayland was disabled for this snap in https://github.com/extraymond/zotero-snap/pull/1, however Zotero enabled Wayland by default in version 7: https://forums.zotero.org/discussion/90954/native-wayland-support